### PR TITLE
Setlist Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
   - [ ] usb connectors
   - [ ] midi
 - [ ] performance improvements (only send serial/midi on change)
+- [ ] ableton mode
+- [ ] setlist mode
 
 ## EVENTS
 - Press (P): When HIGH, wait 50 ms for no other adjacent switch, trigger, trigger P
@@ -49,6 +51,21 @@
 
 ## LOOPER (white)
 - 1 2 & 3 control the looper bank up/down/undo
+
+## ABLETON (yellow)
+- 1 play
+- 3 up
+- 5 stop
+
+## SETLIST (yellow)
+- 1 bank up
+- 2 bank down
+- Bank search mode flashing bank leds - select 1-5 to confirm
+- tap mode does ableton stop
+- 3, 4, 5 select patch (switch to preset, start pads)
+- second tap of 3, 4, 5 trigger ableton loop
+- 3, 4, 5 on a setlist preset with no ableton data will not change ableton
+- PH mode goes back to previous mode
 
 ## COPYSWAPSAVE (purple)
 - 1 bank down

--- a/lib/SetlistPreset/SetlistPreset.cpp
+++ b/lib/SetlistPreset/SetlistPreset.cpp
@@ -17,3 +17,15 @@ int SetlistPreset::getAbleton1() {
 int SetlistPreset::getAbleton2() {
     return ableton2;
 }
+
+void SetlistPreset::setPresetNum(int num) {
+    presetNum = num;
+}
+
+void SetlistPreset::setAbleton1(int num) {
+    ableton1 = num;
+}
+
+void SetlistPreset::setAbleton2(int num) {
+    ableton2 = num;
+}

--- a/lib/SetlistPreset/SetlistPreset.cpp
+++ b/lib/SetlistPreset/SetlistPreset.cpp
@@ -1,0 +1,19 @@
+#include <SetlistPreset.h>
+
+SetlistPreset::SetlistPreset(int initPresetNum, int initAbleton1, int initAbleton2) {
+    presetNum = initPresetNum;
+    ableton1 = initAbleton1;
+    ableton2 = initAbleton2;
+}
+
+int SetlistPreset::getPresetNum() {
+    return presetNum;
+}
+
+int SetlistPreset::getAbleton1() {
+    return ableton1;
+}
+
+int SetlistPreset::getAbleton2() {
+    return ableton2;
+}

--- a/lib/SetlistPreset/SetlistPreset.h
+++ b/lib/SetlistPreset/SetlistPreset.h
@@ -14,6 +14,9 @@ class SetlistPreset
         int getPresetNum();
         int getAbleton1();
         int getAbleton2();
+        void setPresetNum(int num);
+        void setAbleton1(int num);
+        void setAbleton2(int num);
 };
 
 #endif //SetlistPreset_h

--- a/lib/SetlistPreset/SetlistPreset.h
+++ b/lib/SetlistPreset/SetlistPreset.h
@@ -1,0 +1,19 @@
+#ifndef SetlistPreset_h
+#define SetlistPreset_h
+
+#include <Arduino.h>
+
+class SetlistPreset
+{
+    private:
+        int presetNum;
+        int ableton1;
+        int ableton2;
+    public:
+        SetlistPreset(int presetNum, int ableton1, int ableton2);
+        int getPresetNum();
+        int getAbleton1();
+        int getAbleton2();
+};
+
+#endif //SetlistPreset_h

--- a/lib/State/State.cpp
+++ b/lib/State/State.cpp
@@ -43,7 +43,7 @@ bool State::diff(State* state) {
 
 State* State::copy() {
     State* newState;
-    newState->setState(currentPreset, currentSetlistPreset, midi1, midi2, loops, looper);
+    newState->setState(currentPreset, currentSetlistPreset, midi1, midi2, currentAbleton, loops, looper);
     return newState;
 }
 
@@ -208,6 +208,10 @@ int State::getPatch() {
     return currentPreset % PPB;
 }
 
+int State::getSetlistPatch() {
+    return currentSetlistPreset % PPB;
+}
+
 int State::getPatchForPresetNum(int num) {
     return num % PPB;
 }
@@ -269,15 +273,15 @@ void State::abletonPlay(int num) {
 }
 
 void State::abletonSelectUp() {
-    ableton++;
-    if (ableton > 15) {
-        ableton = 15;
+    currentAbleton++;
+    if (currentAbleton > 15) {
+        currentAbleton = 15;
     }
 }
 
 void State::abletonSelectDown() {
-    if (ableton < 1) {
-    ableton--;
-        ableton = 1;
+    if (currentAbleton < 1) {
+    currentAbleton--;
+        currentAbleton = 1;
     }
 }

--- a/lib/State/State.cpp
+++ b/lib/State/State.cpp
@@ -4,17 +4,18 @@ int PPB = 3; // patches per bank
 int NUM_BANKS = 15; // binary 3 digits (not zero)
 int MAX_PRESETS = PPB * NUM_BANKS;
 
-State::State() : currentPreset(0), currentSetlistPreset(0), tempBank(-1), setlistTempBank(-1), midi1(0x00), midi2(0x00), loops(0x00) {
+State::State() : currentPreset(0), currentSetlistPreset(0), tempBank(-1), setlistTempBank(-1), currentAbleton(1), midi1(0x00), midi2(0x00), loops(0x00) {
     for (int i = 0; i < 3; i++) {
         looper[i] = 0;
     }
 }
 
-void State::setState(int newPreset, int newSetlistPreset, int newMidi1, int newMidi2, unsigned char newLoops, int newLooper[]) {
+void State::setState(int newPreset, int newSetlistPreset, int newMidi1, int newMidi2, int newAbleton, unsigned char newLoops, int newLooper[]) {
     currentPreset = newPreset;
     currentSetlistPreset = newSetlistPreset;
     midi1 = newMidi1;
     midi2 = newMidi2;
+    currentAbleton = newAbleton;
     loops = newLoops;
     for (int i = 0; i < 3; i++) {
         looper[i] = newLooper[i];
@@ -148,7 +149,7 @@ int State::selectPatch(int num, bool useTempBank) {
 }
 
 int State::selectSetlistPatchByNum(int num) {
-    currentPreset = num;
+    currentSetlistPreset = num;
 }
 
 int State::selectSetlistPatch(int num) {
@@ -219,6 +220,10 @@ int State::getTempPresetNum(int num) {
     return getTempBank() * PPB + num;
 }
 
+int State::getTempSetlistPresetNum(int num) {
+    return getSetlistTempBank() * PPB + num;
+}
+
 unsigned char State::getLoops() {
     return loops;
 }
@@ -261,4 +266,18 @@ void State::abletonStop() {
 }
 
 void State::abletonPlay(int num) {
+}
+
+void State::abletonSelectUp() {
+    ableton++;
+    if (ableton > 15) {
+        ableton = 15;
+    }
+}
+
+void State::abletonSelectDown() {
+    if (ableton < 1) {
+    ableton--;
+        ableton = 1;
+    }
 }

--- a/lib/State/State.cpp
+++ b/lib/State/State.cpp
@@ -4,14 +4,15 @@ int PPB = 3; // patches per bank
 int NUM_BANKS = 15; // binary 3 digits (not zero)
 int MAX_PRESETS = PPB * NUM_BANKS;
 
-State::State() : currentPreset(0), tempBank(-1), midi1(0x00), midi2(0x00), loops(0x00) {
+State::State() : currentPreset(0), currentSetlistPreset(0), tempBank(-1), setlistTempBank(-1), midi1(0x00), midi2(0x00), loops(0x00) {
     for (int i = 0; i < 3; i++) {
         looper[i] = 0;
     }
 }
 
-void State::setState(int newPreset, int newMidi1, int newMidi2, unsigned char newLoops, int newLooper[]) {
+void State::setState(int newPreset, int newSetlistPreset, int newMidi1, int newMidi2, unsigned char newLoops, int newLooper[]) {
     currentPreset = newPreset;
+    currentSetlistPreset = newSetlistPreset;
     midi1 = newMidi1;
     midi2 = newMidi2;
     loops = newLoops;
@@ -22,6 +23,9 @@ void State::setState(int newPreset, int newMidi1, int newMidi2, unsigned char ne
 
 bool State::diff(State* state) {
     if (currentPreset != state->currentPreset) {
+        return true;
+    }
+    if (currentSetlistPreset != state->currentSetlistPreset) {
         return true;
     }
     if (midi1 != state->midi1) {
@@ -38,7 +42,7 @@ bool State::diff(State* state) {
 
 State* State::copy() {
     State* newState;
-    newState->setState(currentPreset, midi1, midi2, loops, looper);
+    newState->setState(currentPreset, currentSetlistPreset, midi1, midi2, loops, looper);
     return newState;
 }
 
@@ -104,6 +108,32 @@ void State::clearTempBank() {
     tempBank = -1;
 }
 
+void State::setlistBankUp() {
+    if (setlistTempBank == -1) {
+        setlistTempBank = getSetlistBank() + 1;
+    } else {
+        setlistTempBank++;
+    }
+    if (setlistTempBank > NUM_BANKS - 1) {
+        setlistTempBank = 0;
+    }
+}
+
+void State::setlistBankDown() {
+    if (setlistTempBank == -1) {
+        setlistTempBank = getSetlistBank() - 1;
+    } else {
+        setlistTempBank--;
+    }
+    if (setlistTempBank < 0) {
+        setlistTempBank = NUM_BANKS - 1;
+    }
+}
+
+void State::clearSetlistTempBank() {
+    setlistTempBank = -1;
+}
+
 int State::selectPatchByNum(int num) {
     currentPreset = num;
 }
@@ -113,8 +143,21 @@ int State::selectPatch(int num) {
 }
 
 int State::selectPatch(int num, bool useTempBank) {
-    selectPatchByNum(tempBank * PPB + num);
+    selectPatchByNum(setlistTempBank * PPB + num);
     clearTempBank();
+}
+
+int State::selectSetlistPatchByNum(int num) {
+    currentPreset = num;
+}
+
+int State::selectSetlistPatch(int num) {
+    selectSetlistPatchByNum(getSetlistBank() * PPB + num);
+}
+
+int State::selectSetlistPatch(int num, bool useTempBank) {
+    selectSetlistPatchByNum(setlistTempBank * PPB + num);
+    clearSetlistTempBank();
 }
 
 void State::activateLoop(int num) {
@@ -138,11 +181,24 @@ int State::getBank() {
     return currentPreset / PPB;
 }
 
+int State::getSetlistBank() {
+    /* return currentPreset / PPB; */
+    return currentSetlistPreset / PPB;
+}
+
 int State::getTempBank() {
     if (tempBank == -1) {
         return getBank();
     } else {
         return tempBank;
+    }
+}
+
+int State::getSetlistTempBank() {
+    if (setlistTempBank == -1) {
+        return getSetlistBank();
+    } else {
+        return setlistTempBank;
     }
 }
 
@@ -193,4 +249,16 @@ void State::setMidi1(int num) {
 
 void State::setMidi2(int num) {
     midi2 = num;
+}
+
+void State::abletonPlay() {
+}
+
+void State::abletonUp() {
+}
+
+void State::abletonStop() {
+}
+
+void State::abletonPlay(int num) {
 }

--- a/lib/State/State.h
+++ b/lib/State/State.h
@@ -19,8 +19,9 @@ class State
         int getSetlistBank();
         int getPatch();
         int getPatchForPresetNum(int num);
+        int getSetlistPatch();
         State();
-        void setState(int newPreset, int newSetlistPreset, int newMidi1, int newMidi2, unsigned char newLoops, int newLooper[]);
+        void setState(int newPreset, int newSetlistPreset, int newMidi1, int newMidi2, int ableton, unsigned char newLoops, int newLooper[]);
         bool diff(State* state);
         State* copy();
         void midi1Up();

--- a/lib/State/State.h
+++ b/lib/State/State.h
@@ -7,16 +7,19 @@ class State
 {
     public:
         int currentPreset;
+        int currentSetlistPreset;
         int tempBank;
+        int setlistTempBank;
         int midi1;
         int midi2;
         int looper[3];
         unsigned char loops;
         int getBank();
+        int getSetlistBank();
         int getPatch();
         int getPatchForPresetNum(int num);
         State();
-        void setState(int newPreset, int newMidi1, int newMidi2, unsigned char newLoops, int newLooper[]);
+        void setState(int newPreset, int newSetlistPreset, int newMidi1, int newMidi2, unsigned char newLoops, int newLooper[]);
         bool diff(State* state);
         State* copy();
         void midi1Up();
@@ -26,7 +29,14 @@ class State
         void bankUp();
         void bankDown();
         void clearTempBank();
+        void setlistBankUp();
+        void setlistBankDown();
+        void clearSetlistTempBank();
+        int selectSetlistPatchByNum(int num);
+        int selectSetlistPatch(int num);
+        int selectSetlistPatch(int num, bool useTempBank);
         int getTempBank();
+        int getSetlistTempBank();
         int selectPatchByNum(int num);
         int selectPatch(int num);
         int selectPatch(int num, bool useTempBank);
@@ -44,6 +54,10 @@ class State
         void neutralizeLooperControl(int num);
         void setMidi1(int num);
         void setMidi2(int num);
+        void abletonPlay();
+        void abletonUp();
+        void abletonStop();
+        void abletonPlay(int num);
 };
 
 #endif //State_h

--- a/lib/State/State.h
+++ b/lib/State/State.h
@@ -10,6 +10,7 @@ class State
         int currentSetlistPreset;
         int tempBank;
         int setlistTempBank;
+        int currentAbleton;
         int midi1;
         int midi2;
         int looper[3];
@@ -46,6 +47,7 @@ class State
         void setLoops(unsigned char loops);
         int getPresetNum(int num);
         int getTempPresetNum(int num);
+        int getTempSetlistPresetNum(int num);
         unsigned char getLoops();
         int getMidi1();
         int getMidi2();
@@ -58,6 +60,8 @@ class State
         void abletonUp();
         void abletonStop();
         void abletonPlay(int num);
+        void abletonSelectUp();
+        void abletonSelectDown();
 };
 
 #endif //State_h

--- a/lib/Storage/Storage.cpp
+++ b/lib/Storage/Storage.cpp
@@ -109,3 +109,24 @@ int Storage::getStartupPreset() {
     // byte 3
     return EEPROM.read(3);
 }
+
+void Storage::savePresetNumToSetlistPreset(int presetNum, int num) {
+    int base = 4 + ( 3 * 15 );
+    base += num;
+
+    EEPROM.write(base, presetNum);
+}
+
+void Storage::saveAbleton1ToSetlistPreset(int ableton1, int num) {
+    int base = 4 + ( 3 * 15 );
+    base += num;
+
+    EEPROM.write(base + 1, ableton1);
+}
+
+void Storage::saveAbleton2ToSetlistPreset(int ableton2, int num) {
+    int base = 4 + ( 3 * 15 );
+    base += num;
+
+    EEPROM.write(base + 2, ableton2);
+}

--- a/lib/Storage/Storage.cpp
+++ b/lib/Storage/Storage.cpp
@@ -58,6 +58,19 @@ Preset* Storage::getPresetByNum(int num) {
     return preset;
 }
 
+SetlistPreset* Storage::getSetlistPresetByNum(int num) {
+    int base = 4 + ( 3 * 16 );
+    base += num;
+
+    int readPreset   = EEPROM.read(base);
+    int readAbleton1 = EEPROM.read(base + 1);
+    int readAbleton2 = EEPROM.read(base + 2);
+
+    SetlistPreset *setlistPreset = new SetlistPreset(readPreset, readAbleton1, readAbleton2);
+
+    return setlistPreset;
+}
+
 unsigned char Storage::getStartupLoops() {
     unsigned char byte = EEPROM.read(0);
 

--- a/lib/Storage/Storage.cpp
+++ b/lib/Storage/Storage.cpp
@@ -59,7 +59,7 @@ Preset* Storage::getPresetByNum(int num) {
 }
 
 SetlistPreset* Storage::getSetlistPresetByNum(int num) {
-    int base = 4 + ( 3 * 16 );
+    int base = 4 + ( 3 * 15 );
     base += num;
 
     int readPreset   = EEPROM.read(base);

--- a/lib/Storage/Storage.h
+++ b/lib/Storage/Storage.h
@@ -22,6 +22,9 @@ class Storage
         int getStartupMidi1();
         int getStartupMidi2();
         int getStartupPreset();
+        void savePresetNumToSetlistPreset(int presetNum, int num);
+        void saveAbleton1ToSetlistPreset(int ableton1, int num);
+        void saveAbleton2ToSetlistPreset(int ableton2, int num);
 };
 
 #endif //Storage_h

--- a/lib/Storage/Storage.h
+++ b/lib/Storage/Storage.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 #include <EEPROM.h>
 #include <Preset.h>
+#include <SetlistPreset.h>
 #include <State.h>
 
 class Storage
@@ -15,6 +16,7 @@ class Storage
         void saveLoopsToPreset(unsigned char loops, int num);
         void saveMidiToPreset(int midi1, int midi2, int num);
         Preset* getPresetByNum(int num);
+        SetlistPreset* getSetlistPresetByNum(int num);
         unsigned char getStartupLoops();
         int getStartupMode();
         int getStartupMidi1();

--- a/src/sketch.ino
+++ b/src/sketch.ino
@@ -624,7 +624,7 @@ void update() {
             transition(prevMode);
         }
         if (pressHold[5]) {
-            buildingSetlistPreset->setAbleton1(state->ableton);
+            buildingSetlistPreset->setAbleton1(state->currentAbleton);
             transition(SETLISTSAVE);
         }
     } else if (mode == SETLISTSAVE) {
@@ -651,9 +651,9 @@ void update() {
                 targetSetlistPresetNum = state->getTempSetlistPresetNum(2);
             }
 
-            storage->savePresetNumToSetlistPreset(buildingSetlistPreset->getPrestNum(), targetSetlistPresetNum);
-            storage->saveAbleton1ToSetlistPreset(buildingSetlistPreset->ableton1(), targetSetlistPresetNum);
-            storage->saveAbleton2ToSetlistPreset(buildingSetlistPreset->ableton2(), targetSetlistPresetNum);
+            storage->savePresetNumToSetlistPreset(buildingSetlistPreset->getPresetNum(), targetSetlistPresetNum);
+            storage->saveAbleton1ToSetlistPreset(buildingSetlistPreset->getAbleton1(), targetSetlistPresetNum);
+            storage->saveAbleton2ToSetlistPreset(buildingSetlistPreset->getAbleton2(), targetSetlistPresetNum);
 
             transition(SETLISTSAVEWAIT);
         }
@@ -679,11 +679,14 @@ void render() {
         on = (( millis() - copySwapSaveStart ) / 5) % 2;
     }
 
-    if (mode != COPYSWAPSAVEWAIT || on) {
-        lightgrid->setMode(colors[0], colors[1], colors[2]);
+    if (mode == COPYSWAPSAVEWAIT || mode == SETLISTSAVEWAIT) {
+        if (on) {
+            lightgrid->setMode(colors[0], colors[1], colors[2]);
+        } else {
+            lightgrid->setMode(0, 0, 0);
+        }
     } else {
-        // flash on COPYSWAPSAVEWAIT
-        lightgrid->setMode(0, 0, 0);
+        lightgrid->setMode(colors[0], colors[1], colors[2]);
     }
 
     // lightgrid->turnOffAll();
@@ -758,6 +761,22 @@ void render() {
         if (press[3] || pressed[3]) {
             ledStates[2] = true;
         }
+    } else if (mode == ABLETON) {
+    } else if (mode == SETLIST) {
+        if (press[1] || pressed[1]) {
+            ledStates[0] = true;
+        }
+        if (press[2] || pressed[2]) {
+            ledStates[1] = true;
+        }
+        // light up bank leds
+        int bank = state->getSetlistBank() + 1;
+        for (i = 0; i < 4; i++) {
+            if((bank >> i) & 1) {
+                ledStates[(3-i)+5] = true;
+            }
+        }
+        ledStates[state->getSetlistPatch() + 2] = true;
     } else if (mode == COPYSWAPSAVE) {
         // light up bank leds
         int bank = state->getTempBank() + 1;
@@ -777,6 +796,49 @@ void render() {
         if (targetPresetNum != -1) {
             ledStates[state->getPatchForPresetNum(targetPresetNum) + 2] = true;
         }
+    } else if (mode == SETLISTPRESETBUILD1) {
+        if (press[1] || pressed[1]) {
+            ledStates[0] = true;
+        }
+        if (press[2] || pressed[2]) {
+            ledStates[1] = true;
+        }
+        // light up bank leds
+        int bank = state->getTempBank() + 1;
+        for (i = 0; i < 4; i++) {
+            if((bank >> i) & 1) {
+                ledStates[(3-i)+5] = true;
+            }
+        }
+    } else if (mode == SETLISTPRESETBUILD2) {
+        if (press[1] || pressed[1]) {
+            ledStates[0] = true;
+        }
+        if (press[2] || pressed[2]) {
+            ledStates[1] = true;
+        }
+        // light up bank leds as binary representation of state->ableton
+        int bank = state->currentAbleton;
+        for (i = 0; i < 4; i++) {
+            if((bank >> i) & 1) {
+                ledStates[(3-i)+5] = true;
+            }
+        }
+    } else if (mode == SETLISTSAVE || mode == SETLISTSAVEWAIT) {
+        if (press[1] || pressed[1]) {
+            ledStates[0] = true;
+        }
+        if (press[2] || pressed[2]) {
+            ledStates[1] = true;
+        }
+        // light up bank leds
+        int bank = state->getSetlistBank() + 1;
+        for (i = 0; i < 4; i++) {
+            if((bank >> i) & 1) {
+                ledStates[(3-i)+5] = true;
+            }
+        }
+        ledStates[state->getSetlistPatch() + 2] = true;
     }
     lightgrid->setLeds(ledStates);
 

--- a/src/sketch.ino
+++ b/src/sketch.ino
@@ -761,7 +761,6 @@ void render() {
         if (press[3] || pressed[3]) {
             ledStates[2] = true;
         }
-    } else if (mode == ABLETON) {
     } else if (mode == SETLIST) {
         if (press[1] || pressed[1]) {
             ledStates[0] = true;


### PR DESCRIPTION
New mode where:
- I can trigger a guitar preset along with some pads from Ableton Live
- I can then trigger the click and backing loop for the same scene in Ableton
- I can call up a favorite guitar preset in this mode
- I can press a button to stop all Ableton playback
- I can call up 15 banks of 3 patches of just setlist presets (will never use that much) using the tranditional 1+2 bank up/down and 3-5 patch selection

This mode is accessed by pressing + holding the mode button. New setlist presets can be built by pressing + holding button 3 once in this mode. Building a setlist preset will be a step-by-step process where the user chooses which guitar preset is used, and which Ableton scene number (1-15) is used for pads/loops.
